### PR TITLE
CRAFT-6: Use access token instead of refresh token for expiration extraction

### DIFF
--- a/lib/src/craft/auto_refreshing.dart
+++ b/lib/src/craft/auto_refreshing.dart
@@ -29,7 +29,7 @@ mixin AutoRefreshing on Refreshable {
     required Duration Function(String) tokenExpiration,
   }) {
     _tokenExpiration = tokenExpiration;
-    _refreshTimer = Timer(_tokenExpiration(_refreshToken), refreshTokens);
+    _refreshTimer = Timer(_tokenExpiration(_accessToken), refreshTokens);
   }
 
   /// Cancels the [refreshTimer] and calls the super close method.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: craft
 description: Provides Oauth clients with token auto-refresh support, queueing
   requests, offline support
-version: 1.0.0
+version: 1.0.1
 homepage: https://craftlib.com
 repository: https://github.com/stelynx/craft
 environment:


### PR DESCRIPTION
Resolves #8 